### PR TITLE
Added relay addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,5 @@ crashlytics-build.properties
 fabric.properties
 
 !gradle-wrapper.jar
+
+privatekey

--- a/src/main/java/me/apemanzilla/krist/turbokrist/MinerOptions.java
+++ b/src/main/java/me/apemanzilla/krist/turbokrist/MinerOptions.java
@@ -10,27 +10,46 @@ import java.util.Set;
 
 import com.nativelibs4java.opencl.CLDevice;
 
-import me.apemanzilla.krist.state.NodeState;
 import me.apemanzilla.krist.turbokrist.miners.MinerFactory;
-import me.lignum.jkrist.Address;
 
 public class MinerOptions {
-	private Address address;
+	private String tempAddress, depositAddress;
 
 	private Map<Integer, Integer> workSizes = new HashMap<Integer, Integer>();
 
 	private Set<Integer> devices = new HashSet<Integer>();
 
 	private int stateRefreshRate = 2000;
-
-	public Address getKristAddress() {
-		return address;
+	
+	private String privatekey;
+	private boolean relay;
+	
+	public String getTempAddress() {
+		return tempAddress;
 	}
-
-	public MinerOptions(String address) {
-		this.address = NodeState.getKrist().getAddress(address);
+	
+	public MinerOptions setTempAddress(String tempAddress) {
+		this.tempAddress = tempAddress;
+		return this;
 	}
-
+	
+	public String getDepositAddress() {
+		return depositAddress;
+	}
+	
+	public MinerOptions setDepositAddress(String depositAddress) {
+		this.depositAddress = depositAddress;
+		return this;
+	}
+	
+	public String getMiningAddress() {
+		if (relay) {
+			return getTempAddress();
+		} else {
+			return getDepositAddress();
+		}
+	}
+	
 	public void setWorkSize(int signature, int size) {
 		workSizes.put(signature, size);
 	}
@@ -103,5 +122,22 @@ public class MinerOptions {
 	public void setStateRefreshRate(int stateRefreshRate) {
 		this.stateRefreshRate = stateRefreshRate;
 	}
-
+	
+	public String getPrivatekey() {
+		return privatekey;
+	}
+	
+	public MinerOptions setPrivatekey(String privatekey) {
+		this.privatekey = privatekey;
+		return this;
+	}
+	
+	public boolean isRelay() {
+		return relay;
+	}
+	
+	public MinerOptions setRelay(boolean relay) {
+		this.relay = relay;
+		return this;
+	}
 }

--- a/src/main/java/me/apemanzilla/krist/turbokrist/miners/GPUMiner.java
+++ b/src/main/java/me/apemanzilla/krist/turbokrist/miners/GPUMiner.java
@@ -69,7 +69,7 @@ public final class GPUMiner extends Miner implements Runnable {
 		}
 		this.kernel = program.createKernel("krist_miner_basic");
 		Pointer<Byte> addressPtr = Pointer.allocateBytes(10).order(context.getByteOrder());
-		byte[] addressBytes = MinerUtils.getBytes(options.getKristAddress().getName());
+		byte[] addressBytes = MinerUtils.getBytes(options.getMiningAddress());
 		addressPtr.setArray(addressBytes);
 		this.addressBuffer = context.createByteBuffer(Usage.Input, addressPtr);
 		this.workSize = new int[] { options.getWorkSize(MinerFactory.generateSignature(dev)) };

--- a/src/main/java/me/apemanzilla/krist/turbokrist/miners/Solution.java
+++ b/src/main/java/me/apemanzilla/krist/turbokrist/miners/Solution.java
@@ -11,22 +11,15 @@ import me.lignum.jkrist.Address;
  *
  */
 public class Solution {
-
 	private final String block;
-	private final Address address;
+	private final String address;
 	private final String nonce;
 
 	// TODO: Implement checking of solution validity in constructors
 
-	public Solution(Address address, String block, String nonce) {
-		this.block = block;
-		this.address = address;
-		this.nonce = nonce;
-	}
-
 	public Solution(String address, String block, String nonce) {
 		this.block = block;
-		this.address = NodeState.getKrist().getAddress(address);
+		this.address = address;
 		this.nonce = nonce;
 	}
 
@@ -34,7 +27,7 @@ public class Solution {
 		return block;
 	}
 
-	public Address getAddress() {
+	public String getAddress() {
 		return address;
 	}
 

--- a/turbokrist-cli/src/main/java/me/apemanzilla/krist/turbokrist/cli/Controller.java
+++ b/turbokrist-cli/src/main/java/me/apemanzilla/krist/turbokrist/cli/Controller.java
@@ -101,8 +101,6 @@ public class Controller implements MinerListener, NodeStateListener {
 		
 		if (authedAddress == null) {
 			throw new RuntimeException("Not authorized to access address " + options.getTempAddress());
-		} else if (authedAddress != options.getTempAddress()) {
-			throw new RuntimeException("Authed address is not the same as temp address. This shouldn't happen.");
 		}
 	}
 	
@@ -137,7 +135,7 @@ public class Controller implements MinerListener, NodeStateListener {
 
 				if (block != null) {
 					if (options.isRelay()) {
-						System.out.println("Relaying... ");
+						System.out.print("Relaying... ");
 						
 						Transaction transaction = NodeState.getKrist().makeTransaction(options.getPrivatekey(), options
 							.getDepositAddress(), block.getValue());

--- a/turbokrist-cli/src/main/java/me/apemanzilla/krist/turbokrist/cli/Launcher.java
+++ b/turbokrist-cli/src/main/java/me/apemanzilla/krist/turbokrist/cli/Launcher.java
@@ -26,12 +26,17 @@ import me.apemanzilla.krist.turbokrist.miners.MinerInitException;
  *
  */
 public class Launcher {
+	private static final String NAME_META_REGEX = "^(?:([a-z0-9-_]{1,32})@)?([a-z0-9]{1,64})\\.kst$";
 
 	private static Options options = new Options();
 
 	static {
 		options.addOption(Option.builder("h").longOpt("host").hasArg().argName("address")
 				.desc("The Krist address to mine for").build());
+		options.addOption(Option.builder("p").longOpt("privatekey").hasArg().argName("privatekey")
+				.desc("The privatekey for relay mode.").build());
+		options.addOption(Option.builder().longOpt("relay")
+				.desc("Mine to a temporary address before sending to the host address.").build());
 //		options.addOption(
 //				Option.builder("p").longOpt("profiler").desc("Start the system profiler to optimize mining").build());
 		options.addOption(
@@ -105,7 +110,15 @@ public class Launcher {
 			NodeState.setKrist(new Krist());
 		}
 
-		MinerOptions options = new MinerOptions(cmd.getOptionValue("h"));
+		MinerOptions options = new MinerOptions();
+		options.setDepositAddress(cmd.getOptionValue('h'));
+		
+		if (options.getDepositAddress().matches(NAME_META_REGEX)) {
+			if (verbose)
+				System.out.println("Name detected. Relay enabled - mining to a temporary address.");
+			options.setRelay(true);
+		}
+		
 		if (cmd.hasOption("a")) {
 			if (verbose)
 				System.out.println("Selecting all devices.");
@@ -138,6 +151,17 @@ public class Launcher {
 			if (verbose)
 				System.out.println("Setting refresh rate.");
 			options.setStateRefreshRate(Integer.parseInt(cmd.getOptionValue("r")));
+		}
+		if (cmd.hasOption("p")) {
+			String privatekey = cmd.getOptionValue('p');
+			if (verbose)
+				System.out.println("Using custom privatekey.");
+			options.setPrivatekey(privatekey);
+		}
+		if (cmd.hasOption("relay")) {
+			if (verbose)
+				System.out.println("Relay enabled - mining to a temporary address.");
+			options.setRelay(true);
 		}
 
 		System.out.println("Starting miner...");


### PR DESCRIPTION
This PR adds support for relay addreses. These are particularly useful if you want to mine directly to a name, as you cannot submit blocks to names.

Relay mode can be activated by passing `--relay`, or by setting `-h` to a name, e.g. `metaname@name.kst`.

When relay mode is activated, a privatekey is generated on startup, and stored in the `privatekey` file. Mined blocks will submit to this temporary address, and then immediately transfer the funds to the host address passed by `-h`.

The `privatekey` file can be skipped entirely by passing `-p $PRIVATEKEY` instead, to use a custom privatekey.